### PR TITLE
bugfix: correct overflowing of content on smaller devices and table borders

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is a solution to the [Recipe page challenge on Frontend Mentor](https://www
 ### Links
 
 - Solution URL: [Solution URL here](https://github.com/ownedbyanonymous/recipe-page-main)
-- Live Site URL: [Live site URL here](https://vercel.com/anonymous-projects-2a5e58cd/recipe-page-main-ka9w)
+- Live Site URL: [Live site URL here](https://recipe-page-main-ka9w.vercel.app/)
 
 ## My process
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -145,21 +145,21 @@ section ul, section ol{
     Borders are collapsed into a single border when possible (border-spacing and empty-cells properties have no effect)
 */
 table{
-    width: 100%;
-    border-collapse: collapse;
     margin-bottom: 2.125rem;
+    border-collapse: collapse;
+    width: 100%;
 }
 
 
 td{
     padding-left: 1.125rem;
     text-align: left;
+    border-bottom: 1px solid hsl(30, 18%, 87%);
 }
 
 td:not(:last-child){
-    border-bottom: 1px solid hsl(30, 18%, 87%);
-    padding-bottom: 0.6875rem;
-    padding-top: 0.6875rem
+    /* padding-bottom: 0.6875rem; */
+    padding-top: 0.6875rem;
 }
 
 tr td:nth-child(2){
@@ -167,37 +167,17 @@ tr td:nth-child(2){
     font-weight: 600;
 }
 
-@media (375px<= width <= 700px ) {
-
-    header, .preparation-time, .ingrdients, .instruction, .instruction{
-        flex-shrink: 3;
+@media (300px<= width <= 700px ) {
+    main{
+        width: 100%;
     }
 
-    section ul, section ol{
-        padding-left: 1rem;
-
-        li{
-            padding-left: 0rem;
-        }
-    }
-
-    header{
-        p{
-            width: 90%;
-        }
+    article{
+        width: 80%;
     }
 
     .preparation-time{
-        padding-left: 0.5rem;
-        padding-right: 0.5rem;
-
-        h3{
-            max-width: 50%;
-        }
-    }
-
-    .ingrdients{
-        width: 90%;
+        padding-right: 1rem;
     }
 }
 


### PR DESCRIPTION
# Description

The PR includes bugfixes for the recipe page. Fixes made include changing the main and article element widths to avoid content overflowing on smaller devices. Also addressed in this PR is the issue with the table width and borders not covering the full width of the viewport as per Figma designs. Lastly, a README update of the live URL link was made to point to the correct URL and/or webpage.


## Type of change

Please delete options that are not relevant.

- [✅ ] Bug fix (non-breaking change which fixes an issue)
- [✅] This change requires a documentation update

# How Has This Been Tested?
Only User Acceptance Testing was performed and no other tests

# Checklist:

- [✅ ] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my code
- [✅] I have commented my code, particularly in hard-to-understand areas
- [✅] I have made corresponding changes to the documentation
- [✅] My changes generate no new warnings
- [❌] I have added tests that prove my fix is effective or that my feature works
- [❌] New and existing unit tests pass locally with my changes
- [❌] Any dependent changes have been merged and published in downstream modules

